### PR TITLE
fix: pin `typescript` to `~5.9` in devDependencies

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2,23 +2,24 @@
   "version": "5",
   "specifiers": {
     "npm:@deno/shim-deno@~0.19.2": "0.19.2",
-    "npm:@guolao/vue-monaco-editor@^1.5.5": "1.5.5_monaco-editor@0.53.0_vue@3.5.22",
-    "npm:@iconify-prerendered/vue-codicon@~0.28.1753246500": "0.28.1753246500_vue@3.5.22",
+    "npm:@guolao/vue-monaco-editor@^1.5.5": "1.5.5_monaco-editor@0.53.0_vue@3.5.22__typescript@5.9.3_typescript@5.9.3",
+    "npm:@iconify-prerendered/vue-codicon@~0.28.1753246500": "0.28.1753246500_vue@3.5.22__typescript@5.9.3_typescript@5.9.3",
     "npm:@tauri-apps/api@^2.8.0": "2.8.0",
     "npm:@tauri-apps/cli@^2.8.4": "2.8.4",
     "npm:@tauri-apps/plugin-shell@^2.3.1": "2.3.1",
     "npm:@tsconfig/deno@^1.0.11": "1.0.11",
-    "npm:@typed-sigterm/eslint-config@^1.6.0": "1.6.0_@antfu+eslint-config@5.4.1__eslint@9.37.0__@typescript-eslint+parser@8.45.0___eslint@9.37.0___typescript@5.9.3__@typescript-eslint+eslint-plugin@8.45.0___@typescript-eslint+parser@8.45.0____eslint@9.37.0____typescript@5.9.3___eslint@9.37.0___typescript@5.9.3__@stylistic+eslint-plugin@5.4.0___eslint@9.37.0__vue-eslint-parser@10.2.0___eslint@9.37.0",
-    "npm:@vitejs/plugin-vue@^6.0.1": "6.0.1_vite@7.1.9__picomatch@4.0.3_vue@3.5.22",
+    "npm:@typed-sigterm/eslint-config@^1.6.0": "1.6.0_typescript@5.9.3",
+    "npm:@vitejs/plugin-vue@^6.0.1": "6.0.1_vite@7.1.9__picomatch@4.0.3_vue@3.5.22__typescript@5.9.3_typescript@5.9.3",
     "npm:@vscode-elements/elements@^2.3.1": "2.3.1",
     "npm:monaco-editor@0.53": "0.53.0",
     "npm:sweetalert@^2.1.2": "2.1.2",
+    "npm:typescript@5.9": "5.9.3",
     "npm:vite@^7.1.9": "7.1.9_picomatch@4.0.3",
     "npm:vue-tsc@^3.1.0": "3.1.0_typescript@5.9.3",
-    "npm:vue@^3.5.22": "3.5.22"
+    "npm:vue@^3.5.22": "3.5.22_typescript@5.9.3"
   },
   "npm": {
-    "@antfu/eslint-config@5.4.1_eslint@9.37.0_@typescript-eslint+parser@8.45.0__eslint@9.37.0__typescript@5.9.3_@typescript-eslint+eslint-plugin@8.45.0__@typescript-eslint+parser@8.45.0___eslint@9.37.0___typescript@5.9.3__eslint@9.37.0__typescript@5.9.3_@stylistic+eslint-plugin@5.4.0__eslint@9.37.0_vue-eslint-parser@10.2.0__eslint@9.37.0": {
+    "@antfu/eslint-config@5.4.1_typescript@5.9.3": {
       "integrity": "sha512-x7BiNkxJRlXXs8tIvg0CgMuNo5IZVWkGLMJotCtCtzWUHW78Pmm8PvtXhvLBbTc8683GGBK616MMztWLh4RNjA==",
       "dependencies": [
         "@antfu/install-pkg",
@@ -365,7 +366,7 @@
         "levn"
       ]
     },
-    "@guolao/vue-monaco-editor@1.5.5_monaco-editor@0.53.0_vue@3.5.22": {
+    "@guolao/vue-monaco-editor@1.5.5_monaco-editor@0.53.0_vue@3.5.22__typescript@5.9.3_typescript@5.9.3": {
       "integrity": "sha512-NFGImQ8dBYj6ehIxy1DngPRkctB9b6GbxvCm6aXZztNsgm/TtM4u+YM9ZwZHQPlXt7a4IODXoKCcTYEVycBSyA==",
       "dependencies": [
         "@monaco-editor/loader",
@@ -390,7 +391,7 @@
     "@humanwhocodes/retry@0.4.3": {
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="
     },
-    "@iconify-prerendered/vue-codicon@0.28.1753246500_vue@3.5.22": {
+    "@iconify-prerendered/vue-codicon@0.28.1753246500_vue@3.5.22__typescript@5.9.3_typescript@5.9.3": {
       "integrity": "sha512-Ad9xT2cUCM7E1fmGYb/2pjv05hIYQ6nlxuD68gFcnaN5Wq3I3Y9iOm5fF/qInTpf63PoStaPberFz77dNRaOyA==",
       "dependencies": [
         "vue"
@@ -649,7 +650,7 @@
     "@tsconfig/deno@1.0.11": {
       "integrity": "sha512-vZcyDF2QERhwXFgNyIXsB5GRc2X9JaZsu+6rhLREYFUaQvjY5EhuqqyV9qgiUNUpsvt8JfawxhZ/CFgjhNFBLA=="
     },
-    "@typed-sigterm/eslint-config@1.6.0_@antfu+eslint-config@5.4.1__eslint@9.37.0__@typescript-eslint+parser@8.45.0___eslint@9.37.0___typescript@5.9.3__@typescript-eslint+eslint-plugin@8.45.0___@typescript-eslint+parser@8.45.0____eslint@9.37.0____typescript@5.9.3___eslint@9.37.0___typescript@5.9.3__@stylistic+eslint-plugin@5.4.0___eslint@9.37.0__vue-eslint-parser@10.2.0___eslint@9.37.0": {
+    "@typed-sigterm/eslint-config@1.6.0_typescript@5.9.3": {
       "integrity": "sha512-0u27XT1jNn9uWnsp3C4gYd7QdnmBc5euFcg4hdqDx1N50qGPrkhVw9htT4qvO0wE6TMSkOnxSxl2mRYeRWlCuQ==",
       "dependencies": [
         "@antfu/eslint-config",
@@ -787,7 +788,7 @@
         "eslint-visitor-keys@4.2.1"
       ]
     },
-    "@vitejs/plugin-vue@6.0.1_vite@7.1.9__picomatch@4.0.3_vue@3.5.22": {
+    "@vitejs/plugin-vue@6.0.1_vite@7.1.9__picomatch@4.0.3_vue@3.5.22__typescript@5.9.3_typescript@5.9.3": {
       "integrity": "sha512-+MaE752hU0wfPFJEUAIxqw18+20euHHdxVtMvbFcOEpjEyfqXH/5DCoTHiVJ0J29EhTJdoTkjEv5YBKU9dnoTw==",
       "dependencies": [
         "@rolldown/pluginutils",
@@ -795,12 +796,16 @@
         "vue"
       ]
     },
-    "@vitest/eslint-plugin@1.3.15_eslint@9.37.0": {
+    "@vitest/eslint-plugin@1.3.15_eslint@9.37.0_typescript@5.9.3": {
       "integrity": "sha512-U9NGRhN4QrIsxRl4LITQ/deLD5Hv6MC8KrLx+exFX1ri41naX2EaBJAJdbtAyjGnQnBGaXpC6kNFmQac7Ogm2w==",
       "dependencies": [
         "@typescript-eslint/scope-manager",
         "@typescript-eslint/utils",
-        "eslint"
+        "eslint",
+        "typescript"
+      ],
+      "optionalPeers": [
+        "typescript"
       ]
     },
     "@volar/language-core@2.4.23": {
@@ -903,7 +908,7 @@
         "csstype"
       ]
     },
-    "@vue/server-renderer@3.5.22_vue@3.5.22": {
+    "@vue/server-renderer@3.5.22_vue@3.5.22__typescript@5.9.3_typescript@5.9.3": {
       "integrity": "sha512-gXjo+ao0oHYTSswF+a3KRHZ1WszxIqO7u6XwNHqcqb9JfyIL/pbWrrh/xLv7jeDqla9u+LK7yfZKHih1e1RKAQ==",
       "dependencies": [
         "@vue/compiler-ssr",
@@ -1267,12 +1272,16 @@
         "eslint-compat-utils@0.5.1_eslint@9.37.0"
       ]
     },
-    "eslint-plugin-import-lite@0.3.0_eslint@9.37.0": {
+    "eslint-plugin-import-lite@0.3.0_eslint@9.37.0_typescript@5.9.3": {
       "integrity": "sha512-dkNBAL6jcoCsXZsQ/Tt2yXmMDoNt5NaBh/U7yvccjiK8cai6Ay+MK77bMykmqQA2bTF6lngaLCDij6MTO3KkvA==",
       "dependencies": [
         "@eslint-community/eslint-utils",
         "@typescript-eslint/types",
-        "eslint"
+        "eslint",
+        "typescript"
+      ],
+      "optionalPeers": [
+        "typescript"
       ]
     },
     "eslint-plugin-jsdoc@59.1.0_eslint@9.37.0": {
@@ -2629,7 +2638,7 @@
     "vscode-uri@3.1.0": {
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="
     },
-    "vue-demi@0.14.10_vue@3.5.22": {
+    "vue-demi@0.14.10_vue@3.5.22__typescript@5.9.3_typescript@5.9.3": {
       "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
       "dependencies": [
         "vue"
@@ -2658,14 +2667,18 @@
       ],
       "bin": true
     },
-    "vue@3.5.22": {
+    "vue@3.5.22_typescript@5.9.3": {
       "integrity": "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==",
       "dependencies": [
         "@vue/compiler-dom",
         "@vue/compiler-sfc",
         "@vue/runtime-dom",
         "@vue/server-renderer",
-        "@vue/shared"
+        "@vue/shared",
+        "typescript"
+      ],
+      "optionalPeers": [
+        "typescript"
       ]
     },
     "which@2.0.2": {
@@ -2721,6 +2734,7 @@
         "npm:@vscode-elements/elements@^2.3.1",
         "npm:monaco-editor@0.53",
         "npm:sweetalert@^2.1.2",
+        "npm:typescript@5.9",
         "npm:vite@^7.1.9",
         "npm:vue-tsc@^3.1.0",
         "npm:vue@^3.5.22"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@tauri-apps/cli": "^2.8.4",
     "@typed-sigterm/eslint-config": "^1.6.0",
     "@vitejs/plugin-vue": "^6.0.1",
+    "typescript": "~5.9",
     "vite": "^7.1.9",
     "vue-tsc": "^3.1.0"
   }


### PR DESCRIPTION
## Closes

Closes #4.

## Problem

`package.json` does not list `typescript` as a devDependency, so contributors using `bun install` (or `npm install` without the lockfile) resolve `typescript@7.0.2`, which is outside `@typescript-eslint/*`'s supported peer range and also breaks `vue-tsc`'s deep-import. This breaks lint and type-check before any code even runs:

- `bun run lint` →
  ```
  ESLint: 10.7.0
  TypeError: Cannot read properties of undefined (reading 'Cjs')
      at Object.<anonymous> (.../node_modules/@typescript-eslint/typescript-estree/dist/create-program/shared.js:59:18)
  ```
  (TypeScript 7 removed/renamed the `ts.Extension.Cjs` constant the parser relies on.)

- `bunx vue-tsc --noEmit` →
  ```
  Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/tsc' is not defined by "exports" in .../node_modules/typescript/package.json
      at Object.run (.../node_modules/vue-tsc/index.js:40:32)
  ```
  (`vue-tsc@3.x` deep-imports `./lib/tsc`, which TS 7's `package.json` no longer exposes.)

CI does not hit this because the `lint.yml` / `release.yml` workflows install deps via `deno i --allow-scripts`, which respects `deno.lock` and pins `typescript@5.9.3` transitively. The bug only surfaces for anyone who clones the repo and follows the standard Node/Bun workflow.

## Fix

Add `typescript` to `devDependencies` with the `~5.9` range, which:

- Resolves to `5.9.3` — the same version `deno.lock` already pins transitively (via `vue-tsc`), so this matches what CI runs.
- Stays below TypeScript 6/7 where the breaking changes (`ts.Extension.Cjs` removal, `./lib/tsc` deep-import removed) happened.

```diff
   "devDependencies": {
     "@tauri-apps/cli": "^2.8.4",
     "@typed-sigterm/eslint-config": "^1.6.0",
     "@vitejs/plugin-vue": "^6.0.1",
+    "typescript": "~5.9",
     "vite": "^7.1.9",
     "vue-tsc": "^3.1.0"
   }
```

`deno.lock` is regenerated by `deno i --allow-scripts`. The resolved versions do not change (still `5.9.3`); the diff is a re-organisation of the dependency-graph identifiers (Deno now treats `typescript` as a top-level dependency and surfaces it as a resolved optional peer for the few packages that declare one), and all integrity hashes are unchanged.

## Why no `overrides`?

The issue body suggested optionally adding `"overrides": { "typescript": "<6.1.0" }`. I left it out — `typescript` is only consumed by dev tooling (`vue-tsc`, `@typescript-eslint/*`), all of which already resolve to `5.9.3` now that the top-level pin is in place. `overrides` would force the resolution for all transitive consumers on future dep updates as well, which is broader than this bug requires.

## Verification

Reproduced the original crash on a clean clone (`HEAD` at `a114072`) with Bun 1.2.14, then applied this change and re-ran:

```
$ bun install
+ typescript@5.9.3 (v7.0.2 available)   # pinned, no longer resolves to 7.0.2

$ bun run lint
# exits 0 — no crash, no diagnostics

$ ./node_modules/.bin/vue-tsc --noEmit
# exits 2 — no longer crashes with ERR_PACKAGE_PATH_NOT_EXPORTED;
# pre-existing type errors remain (see below), unchanged from before this PR
```

The pre-existing `vue-tsc` errors (`Cannot find name 'Deno'` in `vite.config.ts:4`, `Property 'MonacoEnvironment' does not exist on type 'Window'` in `src/monaco.ts:8`, and `Cannot find name 'Buffer'` errors from Vite's `node_modules/vite/dist/node/index.d.ts`) are NOT addressed by this PR — they are pre-existing and unrelated to the TS-version crash. Issue #4 mentions one of them (`vite.config.ts:4` reads `Deno.env.get('TAURI_DEV_HOST')` unguarded) as a separate bug.

## Scope

This PR is intentionally one-line in `package.json` plus the regenerated lockfile. The pre-existing `vue-tsc` errors listed above are out of scope.